### PR TITLE
人口構成の種類選択フォームコンポーネント作成 

### DIFF
--- a/src/components/LabeledCheckbox/index.module.scss
+++ b/src/components/LabeledCheckbox/index.module.scss
@@ -6,6 +6,10 @@
   background-color: var(--color-primary-sub);
   border-radius: 16px;
 
+  &:hover {
+    opacity: 0.8;
+  }
+
   // NOTE: :hasは20231201時点ではFirefoxでは動作しないが、要件定義的にはChromeのみ対応で問題ないため使用
   &:has(input[type='checkbox']:checked) {
     font-weight: bold;
@@ -27,17 +31,23 @@
   border: 1px solid var(--color-light-gray);
   border-radius: 3px;
 
+  .label:hover & {
+    border-color: var(--color-secondary-sub);
+  }
+
+  // MEMO: 未チェック時のチェックマークの描画
   &::after {
     position: absolute;
     display: none;
     content: '';
   }
 
+  // MEMO: チェック時のチェックボックスの描画
   input[type='checkbox']:checked ~ & {
     background-color: var(--color-secondary-sub);
     border-color: var(--color-secondary-sub);
 
-    // MEMO: チェック時のチェックマークを描画
+    // MEMO: チェック時のチェックマークの描画
     &::after {
       left: 0.25rem;
       display: block;

--- a/src/components/LabeledRadio/index.module.scss
+++ b/src/components/LabeledRadio/index.module.scss
@@ -1,0 +1,66 @@
+.label {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0.5rem 0.7rem 0.5rem 0.5rem;
+  cursor: pointer;
+  background-color: var(--color-primary-sub);
+  border-radius: 16px;
+
+  // MEMO: 選択中inputを子に持つ時
+  &:has(input[type='radio']:checked) {
+    font-weight: bold;
+    cursor: default;
+    background-color: var(--color-secondary-sub);
+  }
+
+  // MEMO: 非選択inputを子に持つ時
+  &:not(:has(input[type='radio']:checked)) {
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}
+
+.radio {
+  position: relative;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 4px;
+  cursor: pointer;
+
+  // MEMO: 外側のマルの色
+  border: 1px solid var(--color-white);
+  border-radius: 50%;
+
+  // MEMO: 内側のマル
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 50%;
+    height: 50%;
+    content: '';
+    background-color: var(--color-white);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  // MEMO: 選択された時の外側のマルの色
+  &:checked {
+    cursor: default;
+    background-color: var(--color-white);
+    border-color: var(--color-white);
+
+    // MEMO: 選択された時の内側のマルの色
+    &::before {
+      background-color: var(--color-secondary);
+    }
+  }
+
+  // MEMO: 非選択かつホバー時の内側のマルの色
+  .label:hover &:not(&:checked)::before {
+    background-color: var(--color-secondary-sub);
+    border-color: var(--color-secondary-sub);
+  }
+}

--- a/src/components/LabeledRadio/index.stories.tsx
+++ b/src/components/LabeledRadio/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { LabeledRadio } from '.'
+
+const meta = {
+  title: 'components/LabeledRadio',
+  component: LabeledRadio,
+  tags: ['autodocs'],
+  args: {},
+  parameters: {}
+} satisfies Meta<typeof LabeledRadio>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    children: <span>sample text</span>
+  }
+}

--- a/src/components/LabeledRadio/index.tsx
+++ b/src/components/LabeledRadio/index.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx'
+
+import styles from './index.module.scss'
+
+type Props = {
+  children: React.ReactNode
+} & Partial<Omit<React.ComponentProps<'input'>, 'type'>>
+
+/**
+ * スタイルされたラベル付きのラジオボタンコンポーネント
+ *
+ * @param children - ラジオボタンのラベルとして表示する要素
+ * @param props - ラジオボタンに適用するプロパティ
+ */
+export const LabeledRadio = ({ children, ...props }: Props) => {
+  return (
+    <label className={clsx(styles['label'])}>
+      <input {...props} type="radio" className={clsx(styles['radio'])} />
+      {children}
+    </label>
+  )
+}

--- a/src/features/prefectureChart/components/CompositionChart.stories.ts
+++ b/src/features/prefectureChart/components/CompositionChart.stories.ts
@@ -1,123 +1,17 @@
+import { expect } from '@storybook/jest'
+import { within } from '@storybook/testing-library'
+
 import { CompositionChart } from './CompositionChart'
+import { COMPOSITION_PER_PREF_LIST } from '../test/mock'
 
 import type { Meta, StoryObj } from '@storybook/react'
-
-// TODO: テスト作成時にモックデータの記述位置について検討すること
-const mockData = [
-  {
-    prefCode: 1 as const,
-    prefName: '北海道',
-    data: {
-      boundaryYear: 2020,
-      data: [
-        {
-          label: '総人口' as const,
-          data: [
-            { year: 1990, value: 5643647 },
-            { year: 2000, value: 5683062 },
-            { year: 2010, value: 5506419 },
-            { year: 2020, value: 5224614 },
-            { year: 2030, value: 4791592 },
-            { year: 2040, value: 4280427 }
-          ]
-        },
-        {
-          label: '年少人口' as const,
-          data: [
-            { year: 1990, value: 1034251 },
-            { year: 2000, value: 792352 },
-            { year: 2010, value: 657312 },
-            { year: 2020, value: 555804 },
-            { year: 2030, value: 465307 },
-            { year: 2040, value: 391086 }
-          ]
-        },
-        {
-          label: '生産年齢人口' as const,
-          data: [
-            { year: 1990, value: 3924717 },
-            { year: 2000, value: 3832902 },
-            { year: 2010, value: 3482169 },
-            { year: 2020, value: 2945727 },
-            { year: 2030, value: 2594718 },
-            { year: 2040, value: 2140781 }
-          ]
-        },
-        {
-          label: '老年人口' as const,
-          data: [
-            { year: 1990, value: 674881 },
-            { year: 2000, value: 1031552 },
-            { year: 2010, value: 1358068 },
-            { year: 2020, value: 1664023 },
-            { year: 2030, value: 1731567 },
-            { year: 2040, value: 1748560 }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    prefCode: 13 as const,
-    prefName: '東京都',
-    data: {
-      boundaryYear: 2020,
-      data: [
-        {
-          label: '総人口' as const,
-          data: [
-            { year: 1990, value: 11855563 },
-            { year: 2000, value: 12064101 },
-            { year: 2010, value: 13159388 },
-            { year: 2020, value: 14047594 },
-            { year: 2030, value: 13882538 },
-            { year: 2040, value: 13758624 }
-          ]
-        },
-        {
-          label: '年少人口' as const,
-          data: [
-            { year: 1990, value: 1727479 },
-            { year: 2000, value: 1420919 },
-            { year: 2010, value: 1477371 },
-            { year: 2020, value: 1566840 },
-            { year: 2030, value: 1471373 },
-            { year: 2040, value: 1432251 }
-          ]
-        },
-        {
-          label: '生産年齢人口' as const,
-          data: [
-            { year: 1990, value: 8790525 },
-            { year: 2000, value: 8685878 },
-            { year: 2010, value: 8850225 },
-            { year: 2020, value: 8944193 },
-            { year: 2030, value: 8988837 },
-            { year: 2040, value: 8330069 }
-          ]
-        },
-        {
-          label: '老年人口' as const,
-          data: [
-            { year: 1990, value: 1244026 },
-            { year: 2000, value: 1910456 },
-            { year: 2010, value: 2642231 },
-            { year: 2020, value: 3107822 },
-            { year: 2030, value: 3422328 },
-            { year: 2040, value: 3996304 }
-          ]
-        }
-      ]
-    }
-  }
-]
 
 const meta = {
   title: 'prefectureChart/CompositionChart',
   component: CompositionChart,
   tags: ['autodocs'],
   args: {
-    data: mockData,
+    data: COMPOSITION_PER_PREF_LIST,
     chartLabel: '総人口'
   },
   parameters: {}
@@ -127,3 +21,36 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const PlayRenderTitle: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const listItems = canvas.getByText('総人口推移')
+    await expect(listItems).toBeInTheDocument()
+  }
+}
+
+export const PlayRenderTitleProps: Story = {
+  args: {
+    chartTitle: 'Propsタイトル'
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const listItems = canvas.getByText('Propsタイトル')
+    await expect(listItems).toBeInTheDocument()
+  }
+}
+
+export const PlayRenderTitleNoData: Story = {
+  args: {
+    data: []
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const listItems = canvas.getByText('都道府県を選択してください')
+    await expect(listItems).toBeInTheDocument()
+  }
+}

--- a/src/features/prefectureChart/components/SelectableCompositionLabels.module.scss
+++ b/src/features/prefectureChart/components/SelectableCompositionLabels.module.scss
@@ -1,0 +1,21 @@
+.container {
+  padding: 8px 24px;
+  background-color: var(--color-white);
+  border-radius: 8px;
+}
+
+.title {
+  padding: 8px;
+  font-weight: bold;
+  color: var(--color-white);
+  background-color: var(--color-primary);
+  border-radius: 8px;
+}
+
+.flexible-list {
+  display: grid;
+  grid-template: none / repeat(4, 1fr);
+  gap: 2rem;
+  justify-content: start;
+  margin-top: 4px;
+}

--- a/src/features/prefectureChart/components/SelectableCompositionLabels.stories.ts
+++ b/src/features/prefectureChart/components/SelectableCompositionLabels.stories.ts
@@ -1,0 +1,63 @@
+import { expect, jest } from '@storybook/jest'
+import { userEvent, waitFor, within } from '@storybook/testing-library'
+
+import { SelectableCompositionLabels } from './SelectableCompositionLabels'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'prefectureChart/SelectableCompositionLabels',
+  component: SelectableCompositionLabels,
+  tags: ['autodocs'],
+  args: {},
+  parameters: {}
+} satisfies Meta<typeof SelectableCompositionLabels>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  }
+}
+
+const mockRouterPush = jest.fn()
+export const PlayClick: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/',
+        query: {
+          label: '年少人口'
+        },
+        push: mockRouterPush
+      }
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // propsのレンダリングテスト
+    const listItems = canvas.getAllByRole('listitem')
+    expect(listItems).toHaveLength(4)
+
+    // default checkedテスト
+    const firstCheckbox = canvas.getByRole('radio', { name: '年少人口' })
+    expect(firstCheckbox).toBeChecked()
+
+    const secondCheckbox = canvas.getByRole('radio', { name: '総人口' })
+    expect(secondCheckbox).not.toBeChecked()
+
+    // // クリックイベントテスト
+    await userEvent.click(secondCheckbox)
+    await waitFor(() =>
+      expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/?label=総人口')
+    )
+  }
+}

--- a/src/features/prefectureChart/components/SelectableCompositionLabels.tsx
+++ b/src/features/prefectureChart/components/SelectableCompositionLabels.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import clsx from 'clsx'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { memo } from 'react'
+
+import { LabeledRadio } from '@/components/LabeledRadio'
+
+import styles from './SelectableCompositionLabels.module.scss'
+import { CHART_LABELS, LABEL_QUERY_KEY } from '../constants'
+import { isCompositionPerYearLabel } from '../filters'
+
+/**
+ * 人口構成のラベルを選択するフォーム
+ */
+export const SelectableCompositionLabels = memo(() => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const pathName = usePathname()
+
+  const queryLabel = searchParams.get(LABEL_QUERY_KEY)
+  const currentLabel = isCompositionPerYearLabel(queryLabel)
+    ? queryLabel
+    : CHART_LABELS[0]
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newSearchParams = new URLSearchParams(searchParams.toString())
+    newSearchParams.set(LABEL_QUERY_KEY, e.target.value)
+    newSearchParams.sort()
+    // NOTE: decodeURI() はrouter.push内で実行してくれるため不要だが、明示的に指定しておく（重複による副作用がないため）
+    router.push(`${pathName}?${decodeURI(newSearchParams.toString())}`)
+  }
+
+  return (
+    <form>
+      <fieldset className={clsx(styles['container'])}>
+        <legend className={clsx(styles['title'])}>
+          人口構成の種類を選択してください
+        </legend>
+        <ul className={clsx(styles['flexible-list'])}>
+          {CHART_LABELS.map((label) => (
+            <li key={label}>
+              <LabeledRadio
+                value={label}
+                name={label}
+                checked={label === currentLabel}
+                onChange={onChange}
+              >
+                {label}
+              </LabeledRadio>
+            </li>
+          ))}
+        </ul>
+      </fieldset>
+    </form>
+  )
+})
+
+SelectableCompositionLabels.displayName = 'SelectableCompositionLabels'

--- a/src/features/prefectureChart/filters/index.test.ts
+++ b/src/features/prefectureChart/filters/index.test.ts
@@ -1,0 +1,30 @@
+import { CHART_LABELS } from '../constants'
+import { COMPOSITION_PER_PREF_LIST } from '../test/mock'
+
+import { getChartOptions, isCompositionPerYearLabel } from '.'
+
+describe('getChartOptions', () => {
+  it('dataが存在する場合', () => {
+    const target = getChartOptions(COMPOSITION_PER_PREF_LIST, '総人口')
+    expect(target.categories).toStrictEqual([
+      '1990',
+      '2000',
+      '2010',
+      '2020',
+      '2030',
+      '2040'
+    ])
+  })
+
+  it('dataが存在しない場合', () => {
+    const target = getChartOptions([], '総人口')
+    expect(target.categories).toStrictEqual([])
+  })
+})
+
+describe('isCompositionPerYearLabel', () => {
+  expect(isCompositionPerYearLabel('test')).toBeFalsy()
+  test.each(CHART_LABELS)('', (name) => {
+    expect(isCompositionPerYearLabel(name)).toBeTruthy()
+  })
+})

--- a/src/features/prefectureChart/index.ts
+++ b/src/features/prefectureChart/index.ts
@@ -1,2 +1,4 @@
 export * from './components/SelectablePrefecturesContainer'
+export * from './components/SelectableCompositionLabels'
 export * from './components/CompositionChartContainer'
+export * from './api/getPrefectures'

--- a/src/features/prefectureChart/test/mock.ts
+++ b/src/features/prefectureChart/test/mock.ts
@@ -1,0 +1,113 @@
+import type { CompositionPerPref } from '../types'
+
+/**
+ * 都道府県ごとの人口構成モックデータ
+ */
+export const COMPOSITION_PER_PREF_LIST: CompositionPerPref[] = [
+  {
+    prefCode: 1 as const,
+    prefName: '北海道',
+    data: {
+      boundaryYear: 2020,
+      data: [
+        {
+          label: '総人口' as const,
+          data: [
+            { year: 1990, value: 5643647 },
+            { year: 2000, value: 5683062 },
+            { year: 2010, value: 5506419 },
+            { year: 2020, value: 5224614 },
+            { year: 2030, value: 4791592 },
+            { year: 2040, value: 4280427 }
+          ]
+        },
+        {
+          label: '年少人口' as const,
+          data: [
+            { year: 1990, value: 1034251 },
+            { year: 2000, value: 792352 },
+            { year: 2010, value: 657312 },
+            { year: 2020, value: 555804 },
+            { year: 2030, value: 465307 },
+            { year: 2040, value: 391086 }
+          ]
+        },
+        {
+          label: '生産年齢人口' as const,
+          data: [
+            { year: 1990, value: 3924717 },
+            { year: 2000, value: 3832902 },
+            { year: 2010, value: 3482169 },
+            { year: 2020, value: 2945727 },
+            { year: 2030, value: 2594718 },
+            { year: 2040, value: 2140781 }
+          ]
+        },
+        {
+          label: '老年人口' as const,
+          data: [
+            { year: 1990, value: 674881 },
+            { year: 2000, value: 1031552 },
+            { year: 2010, value: 1358068 },
+            { year: 2020, value: 1664023 },
+            { year: 2030, value: 1731567 },
+            { year: 2040, value: 1748560 }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    prefCode: 13 as const,
+    prefName: '東京都',
+    data: {
+      boundaryYear: 2020,
+      data: [
+        {
+          label: '総人口' as const,
+          data: [
+            { year: 1990, value: 11855563 },
+            { year: 2000, value: 12064101 },
+            { year: 2010, value: 13159388 },
+            { year: 2020, value: 14047594 },
+            { year: 2030, value: 13882538 },
+            { year: 2040, value: 13758624 }
+          ]
+        },
+        {
+          label: '年少人口' as const,
+          data: [
+            { year: 1990, value: 1727479 },
+            { year: 2000, value: 1420919 },
+            { year: 2010, value: 1477371 },
+            { year: 2020, value: 1566840 },
+            { year: 2030, value: 1471373 },
+            { year: 2040, value: 1432251 }
+          ]
+        },
+        {
+          label: '生産年齢人口' as const,
+          data: [
+            { year: 1990, value: 8790525 },
+            { year: 2000, value: 8685878 },
+            { year: 2010, value: 8850225 },
+            { year: 2020, value: 8944193 },
+            { year: 2030, value: 8988837 },
+            { year: 2040, value: 8330069 }
+          ]
+        },
+        {
+          label: '老年人口' as const,
+          data: [
+            { year: 1990, value: 1244026 },
+            { year: 2000, value: 1910456 },
+            { year: 2010, value: 2642231 },
+            { year: 2020, value: 3107822 },
+            { year: 2030, value: 3422328 },
+            { year: 2040, value: 3996304 }
+          ]
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
# What
人口構成の種類選択フォームコンポーネントを作成し、
種類を選択すると対象のクエリパラメーターが上書きされ、グラフの種類を選択できるようにした

## Why
画面操作からグラフの種類を選択できる機能のため

## How
- radioボタンを共通コンポーネントとしてLabeledRadio/index.tsxに作成
- 人口構成の選択フォームコンポーネントとしてSelectableCompositionLabels.tsx作成
- テスト追加
