### PR TITLE
都道府県選択を１クリック毎ではなく、一括Submit方式に変更

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -12,6 +12,7 @@
   --color-primary-sub: #d5e4f5;
   --color-secondary: #ff8a00;
   --color-secondary-sub: #ffb45b;
+  --color-third: #107eff;
 }
 
 html,

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -2,58 +2,14 @@
 @use '@styles/_variables' as var;
 
 .main {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  padding: 2rem 2rem 0;
+  padding: 2rem 2rem 1rem;
 
   @include var.mq('md') {
-    padding: 1rem 1rem 0;
-  }
-
-  // MEMO: 画面幅が小さい場合は縦並びにする
-  @include var.mq('sm') {
-    flex-direction: column-reverse;
-    align-items: center;
-    padding: 1rem 0.5rem 0;
-  }
-}
-
-.sub-section {
-  width: 30%;
-  min-width: 160px;
-  max-height: 90vh;
-
-  @include var.mq('md') {
-    width: 160px;
-    overflow-y: scroll;
+    padding: 1rem 1rem 0.5rem;
   }
 
   @include var.mq('sm') {
-    width: 100%;
-    max-height: 120px;
-    margin-top: 0.5rem;
-  }
-}
-
-.main-section {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: calc(map.get(var.$breakpoints, 'lg') - 30% - 2rem);
-  max-height: 90vh;
-  margin-left: 2rem;
-
-  @include var.mq('md') {
-    max-width: calc(100% - 160px - 2rem);
-    margin-left: 1rem;
-  }
-
-  @include var.mq('sm') {
-    gap: 0.5rem;
-    width: 100%;
-    max-width: none;
-    margin-left: 0;
+    padding: 1rem 0.5rem 0.5rem;
   }
 }
 
@@ -61,8 +17,68 @@
   display: flex;
   justify-content: flex-end;
   width: 100%;
-  padding-top: 0.5rem;
-  padding-right: 1rem;
   font-size: 2rem;
   font-weight: bold;
+
+  @include var.mq('md') {
+    font-size: 1.5rem;
+  }
+
+  @include var.mq('sm') {
+    font-size: 1rem;
+  }
+}
+
+.page-contents {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+
+  // MEMO: 画面幅が小さい場合は逆順縦並びにする
+  @include var.mq('sm') {
+    flex-direction: column-reverse;
+    align-items: center;
+  }
+}
+
+.sub-section {
+  width: 100%;
+
+  @include var.mq('md') {
+    max-height: 10rem;
+    overflow-y: scroll;
+  }
+
+  @include var.mq('sm') {
+    max-height: 120px;
+  }
+}
+
+.main-section {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+
+  @include var.mq('sm') {
+    flex-direction: column-reverse;
+    gap: 0.5rem;
+  }
+}
+
+.large-content {
+  width: calc(100% - 180px - 1rem);
+
+  @include var.mq('sm') {
+    width: 100%;
+  }
+}
+
+.small-content {
+  width: 180px;
+
+  @include var.mq('sm') {
+    width: 100%;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,15 +11,21 @@ export default async function Home() {
   if (res.length === 0) throw new Error('prefectures data is empty')
 
   return (
-    <main className={clsx(styles['main'])}>
-      <div className={clsx(styles['sub-section'])}>
-        <SelectableCheckbox data={res} />
-      </div>
-      <section className={clsx(styles['main-section'])}>
-        <h1 className={clsx(styles['page-title'])}>地域・年単位の年齢構成</h1>
-        <SelectableLabels />
-        <ChartContainer prefBaseData={res} />
-      </section>
-    </main>
+    <section className={clsx(styles['main'])}>
+      <h1 className={clsx(styles['page-title'])}>地域・年単位の年齢構成</h1>
+      <main className={clsx(styles['page-contents'])}>
+        <div className={clsx(styles['sub-section'])}>
+          <SelectableCheckbox data={res} />
+        </div>
+        <div className={clsx(styles['main-section'])}>
+          <div className={clsx(styles['large-content'])}>
+            <ChartContainer prefBaseData={res} />
+          </div>
+          <div className={clsx(styles['small-content'])}>
+            <SelectableLabels />
+          </div>
+        </div>
+      </main>
+    </section>
   )
 }

--- a/src/components/LabeledCheckbox/index.module.scss
+++ b/src/components/LabeledCheckbox/index.module.scss
@@ -1,3 +1,5 @@
+@use '@styles/_variables' as var;
+
 .label {
   position: relative;
   display: inline-block;
@@ -15,6 +17,10 @@
     font-weight: bold;
     background-color: var(--color-secondary-sub);
   }
+
+  @include var.mq('sm') {
+    padding: 0.25rem 1rem 0.25rem 2rem;
+  }
 }
 
 .checkbox {
@@ -25,11 +31,11 @@
   display: block;
   width: 1rem;
   height: 1rem;
-  margin-top: -0.5rem;
   content: '';
   background-color: var(--color-white);
   border: 1px solid var(--color-light-gray);
   border-radius: 3px;
+  transform: translate(0, -50%);
 
   .label:hover & {
     border-color: var(--color-secondary-sub);
@@ -55,7 +61,12 @@
       height: 0.75rem;
       border: solid var(--color-white);
       border-width: 0 2px 2px 0;
-      transform: rotate(45deg);
+      transform: translate(0, -25%) rotate(45deg);
     }
+  }
+
+  @include var.mq('sm') {
+    width: 0.75rem;
+    height: 0.75rem;
   }
 }

--- a/src/components/LabeledRadio/index.module.scss
+++ b/src/components/LabeledRadio/index.module.scss
@@ -1,3 +1,5 @@
+@use '@styles/_variables' as var;
+
 .label {
   display: flex;
   flex-direction: row;
@@ -19,6 +21,10 @@
     &:hover {
       opacity: 0.8;
     }
+  }
+
+  @include var.mq('sm') {
+    padding: 0.25rem 0.7rem 0.25rem 0.5rem;
   }
 }
 

--- a/src/features/compositionChart/components/SelectableLabels.tsx
+++ b/src/features/compositionChart/components/SelectableLabels.tsx
@@ -38,15 +38,7 @@ export const SelectableLabels = memo(() => {
   return (
     <form>
       <fieldset className={clsx(styles['container'])}>
-        <legend className={clsx(styles['title'])}>人口構成の種類を選択</legend>
-
-        <button
-          type="button"
-          className={clsx(styles['sub-title'])}
-          onClick={onClickClear}
-        >
-          <span className={clsx(styles['link-text'])}>選択をクリア</span>
-        </button>
+        <legend className={clsx(styles['title'])}>人口構成を選択</legend>
 
         <ul className={clsx(styles['flexible-list'])}>
           {CHART_LABELS.map((label) => (
@@ -62,6 +54,14 @@ export const SelectableLabels = memo(() => {
             </li>
           ))}
         </ul>
+
+        <button
+          type="button"
+          className={clsx(styles['end-item'])}
+          onClick={onClickClear}
+        >
+          <span className={clsx(styles['link-text'])}>選択をクリア</span>
+        </button>
       </fieldset>
     </form>
   )

--- a/src/features/compositionChart/components/ui/SelectableLabels.module.scss
+++ b/src/features/compositionChart/components/ui/SelectableLabels.module.scss
@@ -1,16 +1,15 @@
 @use '@styles/_variables' as var;
 
 .container {
-  position: relative;
   padding: 8px 1rem;
   background-color: var(--color-white);
   border-radius: 8px;
 }
 
-.sub-title {
-  position: absolute;
-  top: -1rem;
-  right: 1rem;
+.end-item {
+  width: 100%;
+  margin-top: 0.5rem;
+  text-align: right;
 }
 
 .link-text {
@@ -27,13 +26,15 @@
 }
 
 .flexible-list {
-  display: grid;
-  grid-template: none / repeat(2, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  justify-content: start;
+  justify-content: flex-start;
   margin-top: 4px;
 
   @include var.mq('sm') {
+    display: grid;
+    grid-template: none / repeat(2, 1fr);
     gap: 0.5rem;
   }
 }

--- a/src/features/prefectures/components/SelectableCheckbox.tsx
+++ b/src/features/prefectures/components/SelectableCheckbox.tsx
@@ -21,23 +21,29 @@ type Props = {
  */
 export const SelectableCheckbox = memo(({ data }: Props) => {
   const [selectedPrefectures, updateQueryParams] = usePrefectureQuery()
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateQueryParams(e.target.value)
+
+  const formAction = (formData: FormData) => {
+    const prefCodes = formData
+      .getAll('prefecture')
+      .map((prefCode) => Number(prefCode))
+    updateQueryParams(prefCodes)
   }
 
   return (
-    <form>
+    <form action={formAction} className={clsx(styles['wrapper'])}>
+      <button type="submit" className={clsx(styles['absolute-button'])}>
+        検索
+      </button>
       <fieldset className={clsx(styles['container'])}>
-        <legend className={clsx(styles.title)}>都道府県を選択</legend>
+        <legend className={clsx(styles['title'])}>都道府県を選択</legend>
         <ol className={clsx(styles['flexible-list'])}>
           {data.map(({ prefCode, prefName }) => (
             <li key={prefCode}>
               <LabeledCheckbox
                 id={String(prefCode)}
-                name={prefName}
+                name="prefecture"
                 value={prefCode}
-                onChange={onChange}
-                checked={selectedPrefectures.includes(String(prefCode))}
+                defaultChecked={selectedPrefectures.includes(String(prefCode))}
               >
                 {prefName}
               </LabeledCheckbox>

--- a/src/features/prefectures/components/ui/SelectableCheckbox.module.scss
+++ b/src/features/prefectures/components/ui/SelectableCheckbox.module.scss
@@ -1,7 +1,12 @@
 @use '@styles/_variables' as var;
 
+.wrapper {
+  position: relative;
+}
+
 .container {
-  padding: 8px 16px;
+  height: 100%;
+  padding: 0 16px 8px;
   background-color: var(--color-white);
   border-radius: 8px;
 
@@ -19,22 +24,47 @@
   border-radius: 8px;
 }
 
+.absolute-button {
+  position: absolute;
+  top: 80%;
+  right: 0;
+  padding: 8px 1rem;
+  color: var(--color-white);
+  background-color: var(--color-third);
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgb(0 0 0 / 25%);
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  @include var.mq('md') {
+    position: sticky;
+    top: 70%;
+    left: 100%;
+  }
+
+  @include var.mq('sm') {
+    top: 0;
+    padding: 4px 12px;
+    transform: translate(0, 2rem);
+  }
+}
+
 .flexible-list {
   display: flex;
   flex-flow: row wrap;
   gap: 8px;
-  justify-content: space-between;
-  margin-top: 4px;
+  justify-content: flex-start;
+  margin-top: 8px;
 
   @include var.mq('md') {
     gap: 4px;
-    justify-content: center;
   }
 
   @include var.mq('sm') {
     flex-flow: row;
     gap: 4px;
     min-width: max-content;
-    margin-top: 0;
   }
 }

--- a/src/features/prefectures/components/ui/SelectableCheckbox.stories.ts
+++ b/src/features/prefectures/components/ui/SelectableCheckbox.stories.ts
@@ -49,23 +49,26 @@ export const PlayClick: Story = {
     const canvas = within(canvasElement)
 
     // propsのレンダリングテスト
-    const listItems = canvas.getAllByRole('listitem')
+    const listItems = await canvas.findAllByRole('listitem')
     expect(listItems).toHaveLength(5)
 
     // default checkedテスト
-    const firstCheckbox = canvas.getByRole('checkbox', { name: '県1' })
+    const firstCheckbox = await canvas.findByRole('checkbox', { name: '県1' })
     expect(firstCheckbox).toBeChecked()
 
-    const secondCheckbox = canvas.getByRole('checkbox', { name: '県2' })
+    const secondCheckbox = await canvas.findByRole('checkbox', { name: '県2' })
     expect(secondCheckbox).not.toBeChecked()
 
-    // クリックイベントテスト
+    // 県2をtrueにする
     userEvent.click(secondCheckbox)
+    // 県1をfalseにする
+    userEvent.click(firstCheckbox)
+
+    const submitButton = await canvas.findByRole('button', { name: '検索' })
+    userEvent.click(submitButton)
+
     await waitFor(() =>
-      expect(mockRouterPush).toHaveBeenNthCalledWith(
-        1,
-        '/?prefecture=1&prefecture=2'
-      )
+      expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/?prefecture=2')
     )
   }
 }

--- a/src/features/prefectures/hooks/usePrefectureQuery.test.ts
+++ b/src/features/prefectures/hooks/usePrefectureQuery.test.ts
@@ -46,7 +46,7 @@ describe('usePrefectureQuery', () => {
     expect(currentParams).toEqual(['1'])
   })
 
-  it('クエリパラーメーターに新しく値を追加する場合', () => {
+  it('クエリパラーメーターを変更する', () => {
     const { mockUsePathname, mockUseRouter } = mockNavigation(
       'prefecture=1&prefecture=2'
     )
@@ -54,27 +54,10 @@ describe('usePrefectureQuery', () => {
     const [, updateParams] = result.current
 
     act(() => {
-      updateParams('3')
+      updateParams([3])
     })
     const { push } = mockUseRouter()
-    expect(push).toHaveBeenNthCalledWith(
-      1,
-      `${mockUsePathname()}?prefecture=1&prefecture=2&prefecture=3`
-    )
-  })
-
-  it('クエリパラーメーターから既存の値を削除する場合', () => {
-    const { mockUsePathname, mockUseRouter } = mockNavigation(
-      'prefecture=1&prefecture=2'
-    )
-    const { result } = renderHook(() => usePrefectureQuery())
-    const [, updateParams] = result.current
-
-    act(() => {
-      updateParams('1')
-    })
-    const { push } = mockUseRouter()
-    expect(push).toHaveBeenNthCalledWith(1, `${mockUsePathname()}?prefecture=2`)
+    expect(push).toHaveBeenNthCalledWith(1, `${mockUsePathname()}?prefecture=3`)
   })
 
   it('他のクエリパラメーターが存在する場合', () => {
@@ -83,12 +66,12 @@ describe('usePrefectureQuery', () => {
     const [, updateParams] = result.current
 
     act(() => {
-      updateParams('2')
+      updateParams([2])
     })
     const { push } = mockUseRouter()
     expect(push).toHaveBeenNthCalledWith(
       1,
-      `${mockUsePathname()}?other=test&prefecture=1&prefecture=2`
+      `${mockUsePathname()}?other=test&prefecture=2`
     )
   })
 })

--- a/src/features/prefectures/hooks/usePrefectureQuery.ts
+++ b/src/features/prefectures/hooks/usePrefectureQuery.ts
@@ -1,6 +1,8 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useCallback } from 'react'
 
+import { PREFECTURE_QUERY_KEY } from '../constants'
+
 /**
  * prefectureクエリパラメーターを管理するためのカスタムフックです。
  *
@@ -11,31 +13,23 @@ export const usePrefectureQuery = () => {
   const pathName = usePathname()
   const searchParams = useSearchParams()
 
-  const currentParams = searchParams.getAll('prefecture')
+  const currentParams = searchParams.getAll(PREFECTURE_QUERY_KEY)
 
   const updateParams = useCallback(
-    (targetValue: string) => {
+    (targetValue: number[]) => {
       const newSearchParams = new URLSearchParams(searchParams.toString())
-      if (currentParams.includes(targetValue)) {
-        newSearchParams.delete('prefecture', targetValue)
-      } else {
-        newSearchParams.append('prefecture', targetValue)
-      }
 
-      // 不正な値を排除し、クエリパラメーターの順番をprefCodeの昇順にする
-      const newPrefCodes = newSearchParams
-        .getAll('prefecture')
-        .filter((code) => Number(code) > 0)
-        .sort((a, b) => Number(a) - Number(b))
-      newSearchParams.delete('prefecture')
+      // クエリパラメーターの順番をprefCodeの昇順にする
+      const newPrefCodes = [...targetValue].sort((a, b) => a - b)
+      newSearchParams.delete(PREFECTURE_QUERY_KEY)
       newPrefCodes.forEach((prefCode) =>
-        newSearchParams.append('prefecture', prefCode)
+        newSearchParams.append(PREFECTURE_QUERY_KEY, String(prefCode))
       )
 
       // クエリパラメーターが1つもない場合はrouter.pushが吸収してくれるため`?`がつかない
       router.push(`${pathName}?${newSearchParams.toString()}`)
     },
-    [currentParams, pathName, router, searchParams]
+    [pathName, searchParams, router]
   )
 
   return [currentParams, updateParams] as const


### PR DESCRIPTION
# What
都道府県ラベルを１クリック毎にクエリパラメータを更新していたが、
複数チェックした上でSubmitボタンをクリックする仕様に変更

## Why
１クリック毎にクエリパラメータを更新すると、スマホレイアウト時の横スクロールが毎度リセットされてしまいUXが悪かったため。
Submitボタンの設置の都合もあり、レイアウトを変更。
極力グラフを大きく表示できるよう横幅を確保したかった、かつSubmitボタンの配置がユーザーにとって違和感ない配置に
する必要があった。

## How
Nextjsの[Client Action](https://zenn.dev/takepepe/articles/server-action-and-use-from-state)を使用してフォームを構成した。
→react-hook-formなどを入れるほどの機能要件ではなく、手軽に実装できるため＆SPAを脱却する際に拡張性があるため採用
